### PR TITLE
Update feed_item.php

### DIFF
--- a/components/feed_item.php
+++ b/components/feed_item.php
@@ -188,6 +188,9 @@ class NEWSFEED_CMP_FeedItem extends OW_Component
             "userIds" => $creatorIdList,
             'createTime' => $action->getCreateTime()
         );
+        
+        //init the var to avoid notice
+        if(!isset($shouldExtend)) { $shouldExtend = ''; }
  
         $shouldExtend = $this->displayType == NEWSFEED_CMP_Feed::DISPLAY_TYPE_ACTIVITY && $lastActivity !== null;
  


### PR DESCRIPTION
This initializes the var to avoid this notice - [Notice] Message: Undefined variable: shouldExtend File: /home/hypwatch/public_html/ow_plugins/newsfeed/components/feed_item.php Line:195